### PR TITLE
Preparing for upgrading installer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@
 *.egg-info
 *~
 __pycache__/
-
+.idea/
 .DS_Store
 .ini
 .pydevproject

--- a/INSTALL
+++ b/INSTALL
@@ -11,7 +11,7 @@ Getting the Source Code
 
 The best way to get the source code is with Git:
 
-  git clone https://bitbucket.org/berkeleylab/openeis.git
+  git clone https://github.com/VOLTTRON/openeis.git
 
 
 Building

--- a/bootstrap.py
+++ b/bootstrap.py
@@ -128,7 +128,7 @@ def get_pip():
     import shutil
     import tempfile
     from urllib.request import urlopen
-    pip_url = 'https://raw.github.com/pypa/pip/master/contrib/get-pip.py'
+    pip_url = 'https://bootstrap.pypa.io/get-pip.py'
     print('Downloading get-pip.py')
     tmpdir = tempfile.mkdtemp()
     try:

--- a/bootstrap_openeis.bat
+++ b/bootstrap_openeis.bat
@@ -1,0 +1,24 @@
+:: export PIP_DOWNLOAD_CACHE=/tmp/pip/cache
+:: set PATH=C:\Program Files (x86)\Git\bin;%PATH%
+
+C:\Python34\python.exe bootstrap.py
+
+:: Install dependencies for running extra things.
+:: env\Scripts\pip.exe install pyflakes
+:: env\Scripts\pip.exe install pylint
+env\Scripts\pip.exe install pytest-django
+
+:: Required export so that tests can be run
+set DJANGO_SETTINGS_MODULE=openeis.server.settings
+
+:: Setup the database
+env\Scripts\openeis.exe syncdb --noinput --no-initial-data
+
+:: Load the exported data
+env\Scripts\openeis.exe loaddata projects_test_auth.json
+
+:: Install numpy for some of the applications to work properly.
+xcopy ..\openeis-setup-support\numpy1.8.2 env\Lib\site-packages /F/E/Y
+
+::env\Scripts\py.test openeis\projects --junitxml=xunit-output.xml --ds=openeis.server.settings
+


### PR DESCRIPTION
Updated bootstrap.py to use current get-pip location
Upgraded to use python3.4 instead of 3.3 (3.3 is deprecated as is 3.4 but it works with 3.4.4 binary installer)
Added pycharm .idea folder to .gitignore file.